### PR TITLE
Pass auto_unbox as a variable to json function

### DIFF
--- a/R/response.R
+++ b/R/response.R
@@ -22,8 +22,8 @@ Response<-
                 self$body<-body
               }
             },
-            json=function(obj){
-              self$body<-jsonlite::toJSON(obj, auto_unbox = TRUE)
+            json=function(obj, auto_unbox = TRUE){
+              self$body<-jsonlite::toJSON(obj, auto_unbox=auto_unbox)
               self$content_type("application/json")
             },
             text=function(text){


### PR DESCRIPTION
Currently the `res$json` function automatically unboxes the object you're converting to JSON. 

In my use case I wanted to send an array with one value. But a list with one value is "unboxed" and just returns the one value.

In the end I manually converted to json with `auto_unbox = FALSE` and used `res$body` to send the response.  This can all be avoided if we can pass a variable for `auto_unbox`.